### PR TITLE
Overwrite model

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ You can install the package via composer:
 composer require stats4sd/filament-team-management
 ```
 
+This package requires Laravel Filament and this package: https://filamentphp.com/plugins/tharinda-rodrigo-spatie-roles-permissions to be installed. Make sure you follow the installation instructions for those packages first:
+
+- https://filamentphp.com/plugins/tharinda-rodrigo-spatie-roles-permissions
+
+
 You can publish and run the migrations with:
 
 ```bash
@@ -76,4 +81,3 @@ Please review [our security policy](../../security/policy) on how to report secu
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
-        "spatie/laravel-package-tools": "^1.15.0"
+        "spatie/laravel-package-tools": "^1.15.0",
+        "awcodes/shout": "^2.0",
+        "althinect/filament-spatie-roles-permissions": "^2.2"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/config/filament-team-management.php
+++ b/config/filament-team-management.php
@@ -3,4 +3,10 @@
 // config for Stats4sd/FilamentTeamManagement
 return [
     'use_programs' => env('FILAMENT_TEAM_MANAGEMENT_USE_PROGRAMS', false),
+
+    'models' => [
+        'user' => env('FILAMENT_TEAM_MANAGEMENT_USER_MODEL', \Stats4sd\FilamentTeamManagement\Models\User::class),
+        'team' => env('FILAMENT_TEAM_MANAGEMENT_TEAM_MODEL', \Stats4sd\FilamentTeamManagement\Models\Team::class),
+        'program' => env('FILAMENT_TEAM_MANAGEMENT_PROGRAM_MODEL', \Stats4sd\FilamentTeamManagement\Models\Program::class),
+    ],
 ];

--- a/src/Filament/Admin/Resources/ProgramResource.php
+++ b/src/Filament/Admin/Resources/ProgramResource.php
@@ -11,13 +11,15 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\ProgramResource\Pages;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\ProgramResource\RelationManagers;
-use Stats4sd\FilamentTeamManagement\Models\Program;
 
 class ProgramResource extends Resource
 {
     protected static ?string $navigationIcon = 'heroicon-o-building-library';
 
-    protected static ?string $model = Program::class;
+    public static function getModel(): string
+    {
+        return config('filament-team-management.models.program');
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/src/Filament/Admin/Resources/ProgramResource/RelationManagers/UsersRelationManager.php
+++ b/src/Filament/Admin/Resources/ProgramResource/RelationManagers/UsersRelationManager.php
@@ -8,7 +8,7 @@ use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Stats4sd\FilamentTeamManagement\Models\Program;
+use Stats4sd\FilamentTeamManagement\Models\Interfaces\ProgramInterface;
 
 class UsersRelationManager extends RelationManager
 {
@@ -81,7 +81,7 @@ class UsersRelationManager extends RelationManager
             ]);
     }
 
-    public function handleInvitation(array $data, Program $program): void
+    public function handleInvitation(array $data, ProgramInterface $program): void
     {
         $program->sendInvites($data['users']);
     }

--- a/src/Filament/Admin/Resources/TeamResource.php
+++ b/src/Filament/Admin/Resources/TeamResource.php
@@ -13,7 +13,6 @@ use Filament\Tables\Table;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\TeamResource\Pages;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\TeamResource\RelationManagers\InvitesRelationManager;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\TeamResource\RelationManagers\UsersRelationManager;
-use Stats4sd\FilamentTeamManagement\Models\Team;
 
 // filament-odk-link package related code are commented as some applications may not require ODK functionalities.
 // Please uncomment those code if filament-odk-link package is required and added to main repo.
@@ -23,7 +22,10 @@ class TeamResource extends Resource
 {
     protected static ?string $navigationIcon = 'heroicon-o-building-office-2';
 
-    protected static ?string $model = Team::class;
+    public static function getModel(): string
+    {
+        return config('filament-team-management.models.team');
+    }
 
     public static function getNavigationGroup(): string
     {

--- a/src/Filament/Admin/Resources/UserResource.php
+++ b/src/Filament/Admin/Resources/UserResource.php
@@ -8,13 +8,15 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\UserResource\Pages;
-use Stats4sd\FilamentTeamManagement\Models\User;
 
 class UserResource extends Resource
 {
     protected static ?string $navigationIcon = 'heroicon-o-users';
 
-    protected static ?string $model = User::class;
+    public static function getModel(): string
+    {
+        return config('filament-team-management.models.user');
+    }
 
     public static function getNavigationGroup(): string
     {
@@ -27,6 +29,8 @@ class UserResource extends Resource
 
     public static function form(Form $form): Form
     {
+        $teamClass = config('filament-team-management.models.team');
+
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
@@ -47,14 +51,16 @@ class UserResource extends Resource
                     ->password()
                     ->revealable(),
 
+                // TODO probably remove password editing here;
+
                 // invite to team (if role is team member)
 
-                // Note - The default setup is to have 'teams' as a belongsToMany for users. This is still the case in this platform (to avoid re-writing the structure), but in this case users will only ever belong to zero or one team. So this is not a 'multiple'.
+                // TODO: make multiple select
                 //
                 // (It's also because there seems to be a bug in Filament where select multiples don't work if the disabled() state is live updated...)
                 \Filament\Forms\Components\Select::make('team_id')
                     ->label('Which team should the user be a member of?')
-                    ->exists('teams', 'id')
+                    ->exists((new $teamClass)->getTable(), 'id')
                     ->relationship('teams', titleAttribute: 'name'),
 
                 // invite to role

--- a/src/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
+++ b/src/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
@@ -29,11 +29,8 @@ class ListUsers extends ListRecords
                                 ->email()
                                 ->required(),
 
-                            // Only show "Super Admin" in role selection box.
-                            // This is to avoid admin invite program admin via role-invite.
-                            // Super admin should create a program then invite program admin for that program
                             Forms\Components\Select::make('role')
-                                ->options(Role::where('name', 'Super Admin')->pluck('name', 'id'))
+                                ->relationship('roles', 'name')
                                 ->required(),
                         ])
                         ->reorderable(false)

--- a/src/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
+++ b/src/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
@@ -6,7 +6,6 @@ use Awcodes\Shout\Components\Shout;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Resources\Pages\ListRecords;
-use Spatie\Permission\Models\Role;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\UserResource;
 
 class ListUsers extends ListRecords

--- a/src/Filament/App/Pages/Programregister.php
+++ b/src/Filament/App/Pages/Programregister.php
@@ -13,9 +13,7 @@ use Illuminate\Auth\Events\Registered;
 use Livewire\Attributes\Url;
 use Spatie\Permission\Models\Role;
 use Stats4sd\FilamentTeamManagement\Http\Responses\RegisterResponse;
-use Stats4sd\FilamentTeamManagement\Models\Program;
 use Stats4sd\FilamentTeamManagement\Models\ProgramInvite;
-use Stats4sd\FilamentTeamManagement\Models\User;
 
 class Programregister extends BaseRegister
 {

--- a/src/Filament/App/Pages/Register.php
+++ b/src/Filament/App/Pages/Register.php
@@ -13,7 +13,6 @@ use Illuminate\Auth\Events\Registered;
 use Livewire\Attributes\Url;
 use Stats4sd\FilamentTeamManagement\Http\Responses\RegisterResponse;
 use Stats4sd\FilamentTeamManagement\Models\TeamInvite;
-use Stats4sd\FilamentTeamManagement\Models\User;
 
 class Register extends BaseRegister
 {

--- a/src/Filament/App/Pages/RegisterProgram.php
+++ b/src/Filament/App/Pages/RegisterProgram.php
@@ -5,7 +5,7 @@ namespace Stats4sd\FilamentTeamManagement\Filament\App\Pages;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Pages\Tenancy\RegisterTenant;
-use Stats4sd\FilamentTeamManagement\Models\Program;
+use Illuminate\Database\Eloquent\Model;
 
 class RegisterProgram extends RegisterTenant
 {
@@ -25,9 +25,9 @@ class RegisterProgram extends RegisterTenant
             ]);
     }
 
-    protected function handleRegistration(array $data): Program
+    protected function handleRegistration(array $data): Model
     {
-        $program = Program::create($data);
+        $program = config('filament-team-management.models.program')::create($data);
 
         $program->users()->attach(auth()->user());
 

--- a/src/Filament/App/Pages/Roleregister.php
+++ b/src/Filament/App/Pages/Roleregister.php
@@ -14,82 +14,86 @@ use Livewire\Attributes\Url;
 use Spatie\Permission\Models\Role;
 use Stats4sd\FilamentTeamManagement\Http\Responses\RegisterResponse;
 use Stats4sd\FilamentTeamManagement\Models\RoleInvite;
-use Stats4sd\FilamentTeamManagement\Models\User;
 
 class Roleregister extends BaseRegister
 {
-    #[Url]
-    public $token = '';
+//    #[Url]
+//    public $token = '';
+//
+//    public ?RoleInvite $invite = null;
+//
+//    public ?array $data = [];
 
-    public ?RoleInvite $invite = null;
+//    public function mount(): void
+//    {
+//        $this->invite = RoleInvite::where('token', $this->token)->firstOrFail();
+//
+//        $this->form->fill([
+//            'email' => $this->invite->email,
+//        ]);
+//    }
+//
+//    public function register(): ?RegistrationResponse
+//    {
+////        try {
+////            $this->rateLimit(2);
+////        } catch (TooManyRequestsException $exception) {
+////            Notification::make()
+////                ->title(__('filament-panels::pages/auth/register.notifications.throttled.title', [
+////                    'seconds' => $exception->secondsUntilAvailable,
+////                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
+////                ]))
+////                ->body(array_key_exists('body', __('filament-panels::pages/auth/register.notifications.throttled') ?: []) ? __('filament-panels::pages/auth/register.notifications.throttled.body', [
+////                    'seconds' => $exception->secondsUntilAvailable,
+////                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
+////                ]) : null)
+////                ->danger()
+////                ->send();
+////
+////            return null;
+////        }
+//
+//        ray('start');
+//
+//        $data = $this->form->getState();
+//
+//        ray($data);
+//        $user = $this->getUserModel()::create($data);
+//
+//        ray($user);
+//        // do not delete rote_invites record, keep them as reference.
+//        // System will not allow the invited user to register again with the same email address.
+//        // $this->invite->delete();
+//
+//        $this->invite->is_confirmed = 1;
+//        $this->invite->save();
+//
+//        // add role to user
+//        $role = Role::find($this->invite->role_id);
+//        $user->assignRole($role);
+//
+//        app()->bind(
+//            \Illuminate\Auth\Listeners\SendEmailVerificationNotification::class,
+//        );
+//
+//        event(new Registered($user));
+//
+//        Filament::auth()->login($user);
+//
+//        session()->regenerate();
+//
+//        // redirect new user to app panel
+//        return app(RegisterResponse::class);
+//    }
 
-    public ?array $data = [];
-
-    public function mount(): void
-    {
-        $this->invite = RoleInvite::where('token', $this->token)->firstOrFail();
-
-        $this->form->fill([
-            'email' => $this->invite->email,
-        ]);
-    }
-
-    public function register(): ?RegistrationResponse
-    {
-        try {
-            $this->rateLimit(2);
-        } catch (TooManyRequestsException $exception) {
-            Notification::make()
-                ->title(__('filament-panels::pages/auth/register.notifications.throttled.title', [
-                    'seconds' => $exception->secondsUntilAvailable,
-                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
-                ]))
-                ->body(array_key_exists('body', __('filament-panels::pages/auth/register.notifications.throttled') ?: []) ? __('filament-panels::pages/auth/register.notifications.throttled.body', [
-                    'seconds' => $exception->secondsUntilAvailable,
-                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
-                ]) : null)
-                ->danger()
-                ->send();
-
-            return null;
-        }
-
-        $data = $this->form->getState();
-        $user = $this->getUserModel()::create($data);
-
-        // do not delete rote_invites record, keep them as reference.
-        // System will not allow the invited user to register again with the same email address.
-        // $this->invite->delete();
-
-        $this->invite->is_confirmed = 1;
-        $this->invite->save();
-
-        // add role to user
-        $role = Role::find($this->invite->role_id);
-        $user->assignRole($role);
-
-        app()->bind(
-            \Illuminate\Auth\Listeners\SendEmailVerificationNotification::class,
-        );
-
-        event(new Registered($user));
-
-        Filament::auth()->login($user);
-
-        session()->regenerate();
-
-        // redirect new user to app panel
-        return app(RegisterResponse::class);
-    }
-
-    protected function getEmailFormComponent(): Component
-    {
-        return Forms\Components\TextInput::make('email')
-            ->label(__('filament-panels::pages/auth/register.form.email.label'))
-            ->email()
-            ->required()
-            ->maxLength(255)
-            ->unique($this->getUserModel())
-            ->readOnly();
-    }
+//    protected function getEmailFormComponent(): Component
+//    {
+//        return Forms\Components\TextInput::make('email')
+//            ->label(__('filament-panels::pages/auth/register.form.email.label'))
+//            ->email()
+//            ->required()
+//            ->maxLength(255)
+//            ->unique($this->getUserModel())
+//            ->readOnly();
+//    }
 }

--- a/src/Filament/Program/Resources/ProgramResource.php
+++ b/src/Filament/Program/Resources/ProgramResource.php
@@ -13,7 +13,6 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Stats4sd\FilamentTeamManagement\Filament\Program\Resources\ProgramResource\Pages;
 use Stats4sd\FilamentTeamManagement\Filament\Program\Resources\ProgramResource\RelationManagers;
-use Stats4sd\FilamentTeamManagement\Models\Program;
 
 class ProgramResource extends Resource
 {
@@ -21,7 +20,10 @@ class ProgramResource extends Resource
 
     protected static ?string $navigationGroup = 'Settings';
 
-    protected static ?string $model = Program::class;
+    public static function getModel(): string
+    {
+        return config('filament-team-management.models.program');
+    }
 
     // when user click on sidebar item, it shows the view page of the selected program directly
     public static function getNavigationItems(): array

--- a/src/Filament/Program/Resources/ProgramResource/RelationManagers/UsersRelationManager.php
+++ b/src/Filament/Program/Resources/ProgramResource/RelationManagers/UsersRelationManager.php
@@ -8,7 +8,7 @@ use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Stats4sd\FilamentTeamManagement\Models\Program;
+use Stats4sd\FilamentTeamManagement\Models\Interfaces\ProgramInterface;
 
 class UsersRelationManager extends RelationManager
 {
@@ -81,7 +81,7 @@ class UsersRelationManager extends RelationManager
             ]);
     }
 
-    public function handleInvitation(array $data, Program $program): void
+    public function handleInvitation(array $data, ProgramInterface $program): void
     {
         $program->sendInvites($data['users']);
     }

--- a/src/Http/Middleware/CheckIfAdmin.php
+++ b/src/Http/Middleware/CheckIfAdmin.php
@@ -4,7 +4,6 @@ namespace Stats4sd\FilamentTeamManagement\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Stats4sd\FilamentTeamManagement\Models\User;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckIfAdmin

--- a/src/Http/Middleware/CheckIfProgramAdmin.php
+++ b/src/Http/Middleware/CheckIfProgramAdmin.php
@@ -4,7 +4,6 @@ namespace Stats4sd\FilamentTeamManagement\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Stats4sd\FilamentTeamManagement\Models\User;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckIfProgramAdmin

--- a/src/Models/Interfaces/ProgramInterface.php
+++ b/src/Models/Interfaces/ProgramInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Stats4sd\FilamentTeamManagement\Models\Interfaces;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+interface ProgramInterface
+{
+    /**
+     * Generate an invitation to join this program for each of the provided email addresses
+     */
+    public function sendInvites(array $emails): void;
+
+    public function invites(): HasMany;
+
+    public function users(): BelongsToMany;
+
+    public function teams(): BelongsToMany;
+
+    // add relationship to refer to program model itself, so that program admin panel > Programs resource can show the selected program for editing
+    public function program(): HasOne;
+}

--- a/src/Models/Interfaces/TeamInterface.php
+++ b/src/Models/Interfaces/TeamInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Stats4sd\FilamentTeamManagement\Models\Interfaces;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+interface TeamInterface
+{
+
+    public function sendInvites(array $emails): void;
+
+    public function invites(): HasMany;
+    public function users(): BelongsToMany;
+    public function admins(): BelongsToMany;
+    public function members(): BelongsToMany;
+    public function programs(): BelongsToMany;
+
+
+    // add relationship to refer to team model itself, so that app panel > Teams resource can show the selected team for editing
+    public function team(): HasOne;
+
+}

--- a/src/Models/Program.php
+++ b/src/Models/Program.php
@@ -11,8 +11,9 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 use Spatie\Permission\Models\Role;
 use Stats4sd\FilamentTeamManagement\Mail\InviteProgramAdmin;
+use Stats4sd\FilamentTeamManagement\Models\Interfaces\ProgramInterface;
 
-class Program extends Model
+class Program extends Model implements ProgramInterface
 {
     protected $table = 'programs';
 
@@ -58,12 +59,12 @@ class Program extends Model
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class)->withTimestamps();
+        return $this->belongsToMany(config('filament-team-management.models.user'))->withTimestamps();
     }
 
     public function teams(): BelongsToMany
     {
-        return $this->belongsToMany(Team::class)->withTimestamps();
+        return $this->belongsToMany(config('filament-team-management.models.team'))->withTimestamps();
     }
 
     // add relationship to refer to program model itself, so that program admin panel > Programs resource can show the selected program for editing

--- a/src/Models/ProgramInvite.php
+++ b/src/Models/ProgramInvite.php
@@ -34,12 +34,12 @@ class ProgramInvite extends Model
     // *********** RELATIONSHIPS ************ //
     public function inviter(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'inviter_id');
+        return $this->belongsTo(config('filament-team-management.models.user'), 'inviter_id');
     }
 
     public function program(): BelongsTo
     {
-        return $this->belongsTo(Program::class);
+        return $this->belongsTo(config('filament-team-management.models.program'));
     }
 
     public function confirm(): bool

--- a/src/Models/RoleInvite.php
+++ b/src/Models/RoleInvite.php
@@ -34,7 +34,7 @@ class RoleInvite extends Model
     // *********** RELATIONSHIPS ************ //
     public function inviter(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'inviter_id');
+        return $this->belongsTo(config('filament-team-management.models.user'), 'inviter_id');
     }
 
     public function role(): BelongsTo

--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -10,8 +10,9 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 use Stats4sd\FilamentTeamManagement\Mail\InviteMember;
+use Stats4sd\FilamentTeamManagement\Models\Interfaces\TeamInterface;
 
-class Team extends Model
+class Team extends Model implements TeamInterface
 {
     protected $table = 'teams';
 
@@ -49,32 +50,32 @@ class Team extends Model
 
     public function invites(): HasMany
     {
-        return $this->hasMany(TeamInvite::class);
+        return $this->hasMany(TeamInvite::class, foreignKey: 'team_id', localKey: 'id');
     }
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'team_members')
+        return $this->belongsToMany(config('filament-team-management.models.user'), 'team_members', 'team_id', 'user_id')
             ->withPivot('is_admin');
     }
 
     public function admins(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'team_members')
+        return $this->belongsToMany(config('filament-team-management.models.user'), 'team_members')
             ->withPivot('is_admin')
             ->wherePivot('is_admin', 1);
     }
 
     public function members(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'team_members')
+        return $this->belongsToMany(config('filament-team-management.models.user'), 'team_members')
             ->withPivot('is_admin')
             ->wherePivot('is_admin', 0);
     }
 
     public function programs(): BelongsToMany
     {
-        return $this->belongsToMany(Program::class);
+        return $this->belongsToMany(config('filament-team-management.models.program'));
     }
 
     // add relationship to refer to team model itself, so that app panel > Teams resource can show the selected team for editing

--- a/src/Models/TeamInvite.php
+++ b/src/Models/TeamInvite.php
@@ -32,12 +32,12 @@ class TeamInvite extends Model
     // *********** RELATIONSHIPS ************ //
     public function inviter(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'inviter_id');
+        return $this->belongsTo(config('filament-team-management.models.user'), 'inviter_id');
     }
 
     public function team(): BelongsTo
     {
-        return $this->belongsTo(Team::class);
+        return $this->belongsTo(config('filament-team-management.models.team'));
     }
 
     // ************ METHODS ************ //

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -19,6 +19,8 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 use Spatie\Permission\Traits\HasRoles;
 use Stats4sd\FilamentTeamManagement\Mail\InviteUser;
+use Stats4sd\FilamentTeamManagement\Models\Interfaces\ProgramInterface;
+use Stats4sd\FilamentTeamManagement\Models\Interfaces\TeamInterface;
 
 class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
 {
@@ -88,20 +90,20 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function teams(): BelongsToMany
     {
-        return $this->belongsToMany(Team::class, 'team_members')->withPivot('is_admin');
+        return $this->belongsToMany(config('filament-team-management.models.team'), 'team_members', 'user_id', 'team_id')->withPivot('is_admin');
     }
 
     public function programs(): BelongsToMany
     {
-        return $this->belongsToMany(Program::class);
+        return $this->belongsToMany(config('filament-team-management.models.program'));
     }
 
-    public function belongsToTeam(Team $team): bool
+    public function belongsToTeam(TeamInterface $team): bool
     {
         return $this->teams->contains($team);
     }
 
-    public function belongsToProgram(Program $program): bool
+    public function belongsToProgram(ProgramInterface $program): bool
     {
         return $this->programs->contains($program);
     }
@@ -124,7 +126,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     public function canAccessTenant(Model $tenant): bool
     {
         // add different handling for different panel
-        if ($tenant instanceof (Team::class)) {
+        if ($tenant instanceof (config('filament-team-management.models.team'))) {
             // app panel
             // check permission
             if ($this->can('view all teams')) {
@@ -144,7 +146,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
             // user cannot access this team
             return false;
-        } elseif ($tenant instanceof (Program::class)) {
+        } elseif ($tenant instanceof (config('filament-team-management.models.program'))) {
             // program admin panel
             // check permission
             if ($this->can('view all programs')) {
@@ -167,7 +169,9 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         if ($panel->isDefault()) {
             // app panel
             if ($this->can('view all teams')) {
-                return Team::all();
+//TODO: test
+                return [];
+                //return config('filament-team-management.models.team')::all();
             } else {
                 // find all accessible Team models
                 $allAccessibleTeams = $this->getAllAccessibleTeams();
@@ -176,7 +180,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
             }
         } else {
             // program admin panel
-            return $this->can('view all programs') ? Program::all() : $this->programs;
+            return $this->can('view all programs') ? config('filament-team-management.models.program')::all() : $this->programs;
         }
     }
 
@@ -208,13 +212,13 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     // The last team the user was on.
     public function latestTeam(): BelongsTo
     {
-        return $this->belongsTo(Team::class, 'latest_team_id');
+        return $this->belongsTo(config('filament-team-management.models.team'), 'latest_team_id');
     }
 
     // The last program the user was on.
     public function latestProgram(): BelongsTo
     {
-        return $this->belongsTo(Program::class, 'latest_program_id');
+        return $this->belongsTo(config('filament-team-management.models.program'), 'latest_program_id');
     }
 
     public function getDefaultTenant(Panel $panel): ?Model


### PR DESCRIPTION
fixes #4. 

Adds config items to allow the app developer to specify custom models to use for User, Team and Program. All references to the models inside the package now reference the config item. 

- Adds Team and Program Interfaces that should be used by any custom implementation of those models.
- the pivot tables for belongsToMany relationships still use the same table and column names e.g. "team_member" and "team_id". These are now hard-coded into the relationships on the package models, so they will work even if the app developer changes the name of the App models. 


