### PR TITLE
Fix Program User Table Name

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -101,7 +101,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function programs(): BelongsToMany
     {
-        return $this->belongsToMany(config('filament-team-management.models.program'), 'program_members', 'user_id', 'program_id');
+        return $this->belongsToMany(config('filament-team-management.models.program'), 'program_user', 'user_id', 'program_id');
     }
 
     public function belongsToTeam(TeamInterface $team): bool


### PR DESCRIPTION
This PR is submitted for a minor fix, to change table name from "program_members" to "program_user".

---

When I prepare to deploy holpa PR #33, I did a testing in holpa staging env before deployment.
Error occurred regarding non existing table "program_members".

I proceed to merge the PR and staging env deployment.

"composer install" in deployment script failed because:
 - Required package "stats4sd/filament-team-management" is in the lock file as "dev-main" but that does not satisfy your constraint "^1.0".

I run "composer update" to fix it. Aimed to resume service in staging env first.
"composer update" executed successfully.

However, same error persists after deployment.

I go back to my local env for debugging. I updated User model in vendor/stats4sd/filament-team-management to see if it helps. Problem resolved. I did the same change in staging site via remote login.

Now I submit a PR to fix it.

---

Executed command and output in holpa staging env for reference:

```
PS C:\public\holpa-platform> composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
- Required package "stats4sd/filament-team-management" is in the lock file as "dev-main" but that does not satisfy your constraint "^1.0".
This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
PS C:\public\holpa-platform> composer update 
```