### PR TITLE
Fix: Hide 'programs assigned' column in the Invites table for ManageTeam

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,7 +11,7 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/src/Filament/App/Pages/ManageTeam/TeamInvitesTable.php
+++ b/src/Filament/App/Pages/ManageTeam/TeamInvitesTable.php
@@ -20,8 +20,9 @@ class TeamInvitesTable
             ->columns([
                 TextColumn::make('email'),
                 TextColumn::make('role.name')->label('Roles assigned'),
-                TextColumn::make('team.name')->label(config('filament-team-management.table_names.teams') . ' assigned'),
-                TextColumn::make('project.name')->label(config('filament-team-management.table_names.programs') . ' assigned'),
+                TextColumn::make('team.name')->label(config('filament-team-management.table_names.teams').' assigned'),
+                TextColumn::make('project.name')->label(config('filament-team-management.table_names.programs').' assigned')
+                    ->visible(fn () => config('filament-team-management.use_programs')),
                 TextColumn::make('created_at')->dateTime(),
                 IconColumn::make('is_confirmed')->boolean(),
 


### PR DESCRIPTION
Previous view when `use_programs === false`: 

<img width="2069" height="1342" alt="Sceenshot 2025-12-08 at 13 16 08" src="https://github.com/user-attachments/assets/76e9b8b5-2199-423d-8cbf-a4929a1e783f" />

Fixed View: 

<img width="2073" height="1322" alt="Sceenshot 2025-12-08 at 13 15 49" src="https://github.com/user-attachments/assets/8f7f20cc-0b89-44ef-8718-3d882ceadc7b" />
